### PR TITLE
Use embedded license header instead of full license file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -413,7 +413,18 @@
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
           <!-- Template location -->
-          <header>LICENSE.txt</header>
+          <inlineHeader>
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+Copyright ${inceptionYear}-${currentYear} the original author or authors.
+          </inlineHeader>
           <properties>
             <!-- Values to be substituted in template -->
             <inceptionYear>2012</inceptionYear>


### PR DESCRIPTION
Follows https://github.com/joel-costigliola/assertj-maven-parent-pom/pull/41#issuecomment-529232642